### PR TITLE
Make imports shorter

### DIFF
--- a/src/mykad/__init__.py
+++ b/src/mykad/__init__.py
@@ -1,1 +1,4 @@
+from .mykad import MyKad
+
+
 __version__ = '0.2.0'

--- a/tests/test_mykad.py
+++ b/tests/test_mykad.py
@@ -1,5 +1,5 @@
 import pytest
-from src.mykad.mykad import MyKad
+from src.mykad import MyKad
 from .utils import generate_random_valid_mykad
 
 


### PR DESCRIPTION
Before:
```python
from mykad.mykad import MyKad
````

After:
```python
from mykad import MyKad
```